### PR TITLE
Dash / Disrupt brush on starting position instead of current position

### DIFF
--- a/Assembly-CSharp/BrushCoordinator.cs
+++ b/Assembly-CSharp/BrushCoordinator.cs
@@ -1,4 +1,4 @@
-﻿// ROGUES
+// ROGUES
 // SERVER
 using System.Collections.Generic;
 using UnityEngine;
@@ -388,9 +388,9 @@ public class BrushCoordinator : NetworkBehaviour, IGameEventListener
 	{
 		if (!AbilityUtils.AbilityHasTag(ability, AbilityTags.DontDisruptBrush))
 		{
-			if (caster.IsInBrush())
+			if (caster.GetSquareAtPhaseStart().IsInBrush())
 			{
-				int brushRegion = caster.GetBrushRegion();
+				int brushRegion = caster.GetSquareAtPhaseStart().BrushRegion;
 				DisruptBrush(brushRegion);
 		
 				// custom


### PR DESCRIPTION
After dashing the actor's current board square is changed so it used to disrupt brush at dashing destination instead of the position where it was casted