### PR TITLE
Visibility fixes

### DIFF
--- a/Assembly-CSharp/ActorData.cs
+++ b/Assembly-CSharp/ActorData.cs
@@ -5196,9 +5196,17 @@ public class ActorData : NetworkBehaviour, IGameEventListener
 #if SERVER
 	public void SynchronizeTeamSensitiveData()
 	{
-		// custom
-		TeamSensitiveData_hostile.MoveFromBoardSquare = TeamSensitiveData_authority.MoveFromBoardSquare;
-	}
+        // custom
+        TeamSensitiveData_hostile.MoveFromBoardSquare = TeamSensitiveData_authority.MoveFromBoardSquare;
+
+		// Update current position to enemy players (does not update last known position marker)
+		// without this, if we use an ability and we are invisible to the enemy team, they will see the origin of the ability as the last known position marker (which is incorrect)
+		// if the origin is wrong, the direction of the shoot can look like you received an attack but no damage was dealt.
+		TeamSensitiveData_hostile.BroadcastMovement(GameEventManager.EventType.NormalMovementStart, GetGridPos(), GetCurrentBoardSquare(), MovementType.Teleport, TeleportType.Evasion_DontAdjustToVision, m_serverMovementPath);
+		
+
+    }
+
 #endif
 
 

--- a/Assembly-CSharp/BrushCoordinator.cs
+++ b/Assembly-CSharp/BrushCoordinator.cs
@@ -1,4 +1,4 @@
-﻿// ROGUES
+// ROGUES
 // SERVER
 using System.Collections.Generic;
 using UnityEngine;
@@ -388,9 +388,9 @@ public class BrushCoordinator : NetworkBehaviour, IGameEventListener
 	{
 		if (!AbilityUtils.AbilityHasTag(ability, AbilityTags.DontDisruptBrush))
 		{
-			if (caster.IsInBrush())
+			if (caster.GetSquareAtPhaseStart().IsInBrush())
 			{
-				int brushRegion = caster.GetBrushRegion();
+				int brushRegion = caster.GetSquareAtPhaseStart().BrushRegion;
 				DisruptBrush(brushRegion);
 		
 				// custom

--- a/Assembly-CSharp/ServerActionBuffer.cs
+++ b/Assembly-CSharp/ServerActionBuffer.cs
@@ -1591,9 +1591,6 @@ public class ServerActionBuffer : NetworkBehaviour
 			{
 				request.m_caster.GetPassiveData().OnBreakInvisibility();
 			}
-			
-			// custom
-			request.m_caster.SetServerLastKnownPosSquare(request.m_caster.CurrentBoardSquare, "RunAbilityRequest");
 		}
 		if (BrushCoordinator.Get() != null)
 		{

--- a/Assembly-CSharp/ServerActionBuffer.cs
+++ b/Assembly-CSharp/ServerActionBuffer.cs
@@ -1,4 +1,4 @@
-﻿// ROGUES
+// ROGUES
 // SERVER
 using System;
 using System.Collections.Generic;
@@ -226,6 +226,7 @@ public class ServerActionBuffer : NetworkBehaviour
 				{
 					Log.Info($"Requesting SynchronizeTeamSensitiveData {phase} for {hitActor.DisplayName} for being hit by {abilityRequest.m_caster?.DisplayName}'s ability {abilityRequest.m_ability.m_abilityName}"); // custom
 					hitActor.SynchronizeTeamSensitiveData();
+					hitActor.TeamSensitiveData_hostile.SynchronizeMovementDataTo(hitActor.TeamSensitiveData_authority);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes:
- When an enemy is hit when is out of sight, the player was showed as hit in the last known position, then it was teleported to the real position when he is standing.
- When an enemy uses an ability while out of sight, his last known position was updated, even if the ability did not hit any enemy, causing to reveal his current position.
- If an ability is used without the last know position marker update, the ability showed as it was casted from the last known position instead of the current position