### PR TITLE
Dispelling movement debuffs

### DIFF
--- a/Assembly-CSharp/ActorStatus.cs
+++ b/Assembly-CSharp/ActorStatus.cs
@@ -609,7 +609,13 @@ public class ActorStatus : NetworkBehaviour
 						    && effect.CanBeDispelledByStatusImmunity()
 						    && !effectsToRemove.Contains(effect))
 						{
-							effectsToRemove.Add(effect);
+							// custom - attempt to dispel slow/root, remove the whole effect if failed
+							if (!effect.DispelMovementDebuff())
+							{
+								effectsToRemove.Add(effect);
+							}
+							// rogues
+							// effectsToRemove.Add(effect); 
 						}
 					}
 

--- a/Assembly-CSharp/Effect.cs
+++ b/Assembly-CSharp/Effect.cs
@@ -720,12 +720,21 @@ public class Effect
 	{
 		return false;
 	}
+	
+	// custom
+	public virtual bool DispelMovementDebuff()
+	{
+		return false;
+	}
 
+	// TODO EFFECTS Not dispelling can break things
+	// (e.g. movement range won't update if your Unstoppable wears off but you still have Slow underneath it)
 	public virtual bool CanBeDispelledByStatusImmunity()
 	{
 		return true;
 	}
 
+	// TODO EFFECTS Should be used to merge buffs and debuffs applied on the same phase?
 	public virtual bool WillApplyStatus(StatusType status)
 	{
 		return false;

--- a/Assembly-CSharp/StandardActorEffect.cs
+++ b/Assembly-CSharp/StandardActorEffect.cs
@@ -16,6 +16,7 @@ public class StandardActorEffect : Effect
 	private bool m_shouldPlaySequences = true;
 	private List<StatusType> m_statusAdded = new List<StatusType>();
 	private List<StatusType> m_statusesToAddOnTurnStart = new List<StatusType>();
+	private List<AbilityStatMod> m_statModsApplied = new List<AbilityStatMod>();
 	private int m_absorbToAddOnTurnStart;
 	private bool m_canBeDispelledByStatus;
 
@@ -225,6 +226,7 @@ public class StandardActorEffect : Effect
 		{
 			if (abilityStatMod.stat != StatType.INVALID)
 			{
+				m_statModsApplied.Add(abilityStatMod); // custom
 				actorStats.AddStatMod(abilityStatMod.stat, abilityStatMod.modType, abilityStatMod.modValue);
 			}
 			// rogues
@@ -302,7 +304,11 @@ public class StandardActorEffect : Effect
 			ActorStats actorStats = Target.GetActorStats();
 			// rogues
 			//EquipmentStats equipmentStats = Target.GetEquipmentStats();
-			foreach (AbilityStatMod abilityStatMod in m_data.m_statMods)
+			
+			// custom
+			foreach (AbilityStatMod abilityStatMod in m_statModsApplied)
+			// rogues
+			// foreach (AbilityStatMod abilityStatMod in m_data.m_statMods)
 			{
 				if (abilityStatMod.stat != StatType.INVALID)
 				{
@@ -692,7 +698,9 @@ public class StandardActorEffect : Effect
 
 	public override bool HasDispellableMovementDebuff()
 	{
-		foreach (AbilityStatMod abilityStatMod in m_data.m_statMods)
+		foreach (AbilityStatMod abilityStatMod in m_statModsApplied)
+		// rogues
+		// foreach (AbilityStatMod abilityStatMod in m_data.m_statMods)
 		{
 			if (abilityStatMod.stat != StatType.Movement_Horizontal)
 			{
@@ -709,7 +717,10 @@ public class StandardActorEffect : Effect
 			}
 		}
 		
-		foreach (StatusType statusChange in m_data.m_statusChanges)
+		// custom
+		foreach (StatusType statusChange in m_statusAdded)
+		// rogues
+		// foreach (StatusType statusChange in m_data.m_statusChanges)
 		{
 			if (ActorStatus.IsDispellableMovementDebuff(statusChange))
 			{
@@ -718,6 +729,53 @@ public class StandardActorEffect : Effect
 		}
 		
 		return false;
+	}
+
+	// custom -- see also HasDispellableMovementDebuff
+	public override bool DispelMovementDebuff()
+	{
+		List<AbilityStatMod> statModsToRemove = new List<AbilityStatMod>();
+		foreach (AbilityStatMod abilityStatMod in m_statModsApplied)
+		{
+			if (abilityStatMod.stat != StatType.Movement_Horizontal)
+			{
+				continue;
+			}
+			
+			bool isDebuff = abilityStatMod.modType == ModType.Multiplier
+				? abilityStatMod.modValue < 1f
+				: abilityStatMod.modValue < 0f;
+
+			if (isDebuff)
+			{
+				statModsToRemove.Add(abilityStatMod);
+			}
+		}
+		
+		ActorStats actorStats = Target.GetActorStats();
+		foreach (AbilityStatMod abilityStatMod in statModsToRemove)
+		{
+			m_statModsApplied.Remove(abilityStatMod);
+			actorStats.RemoveStatMod(abilityStatMod.stat, abilityStatMod.modType, abilityStatMod.modValue);
+		}
+
+		List<StatusType> statusesToRemove = new List<StatusType>();
+		foreach (StatusType statusChange in m_statusAdded)
+		{
+			if (ActorStatus.IsDispellableMovementDebuff(statusChange))
+			{
+				statusesToRemove.Add(statusChange);
+			}
+		}
+		
+		ActorStatus actorStatus = Target.GetComponent<ActorStatus>();
+		foreach (StatusType statusType in statusesToRemove)
+		{
+			m_statusAdded.Remove(statusType);
+			actorStatus.RemoveStatus(statusType);
+		}
+		
+		return true;
 	}
 
 	public void OverrideCanBeDispelledByStatusImmunity(bool canBeDispelled)


### PR DESCRIPTION
Situation: Su-Ren casts Spirit Bend with Slow, Helio casts Battleforged with Unstoppable on the same target. If Unstoppable applied first, Spirit Bend just doesn't apply Slow and moves on. If Slow is applied first, Unstoppable dispels the whole Spirit Bend effect as it contains a movement debuff (and when Unstoppable wears off, the target still has Slow status but has full movement as there have been no status changes to trigger an update). 

So it's a race condition resolved by actor order.

Solution 1: Allow effects to handle Unstoppable and remove movement debuff they have applied while keeping the effect itself active.
Solution 2: Effect has WillApplyStatus method which is not used in Rogues. Perhaps we can use it in ExecuteResults to resolve the race condition?

https://discord.com/channels/600425662452465701/1241828879618936893